### PR TITLE
Fix: Resolve SyntaxError in js/ui.js

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -243,7 +243,7 @@ export function renderHabits(habitActionHandlers) {
         li.appendChild(_createHabitControls(habit, index, habits.length, handlers));
         domElements.habitsList.appendChild(li);
     });
-};
+}
 
 /**
  * Updates the gamification display elements in the UI, including level, XP bar,


### PR DESCRIPTION
Removes an unnecessary semicolon at the end of the `renderHabits` function block in `js/ui.js`. This semicolon was identified as the likely cause of an `Uncaught SyntaxError: Unexpected token 'export'` when the file is parsed, particularly when followed by another `export` statement.

This fix addresses the runtime error you reported post-deployment of earlier refactoring changes.